### PR TITLE
hw_dispatcher: Add the thread_local prefix before hw_dispatcher instance

### DIFF
--- a/sources/core/src/hw_dispatcher/hw_dispatcher.cpp
+++ b/sources/core/src/hw_dispatcher/hw_dispatcher.cpp
@@ -23,7 +23,7 @@
 
 namespace dml::core::dispatcher
 {
-    static hw_dispatcher instance{};
+    static thread_local hw_dispatcher instance{};
 
     hw_dispatcher::hw_dispatcher() noexcept
     {


### PR DESCRIPTION
See the unexpected segement fault when integrating DML in
Ceph and root caused the issue, which is related hw_dispatcher instance
definition.