### PR TITLE
Added a macro to expose min batch size

### DIFF
--- a/examples/dml_job_api/job_wrapper_examples.c
+++ b/examples/dml_job_api/job_wrapper_examples.c
@@ -420,7 +420,7 @@ dml_status_t dml_copy_batch_8u(uint8_t *source_first_ptr,
                                dml_job_t *const dml_job_ptr)
 {
     dml_status_t status = DML_STATUS_OK;
-    uint32_t operations_count    = 4u;
+    uint32_t operations_count    = DML_MIN_BATCH_SIZE;
     uint32_t batch_buffer_length = 0u;
 
     status = dml_get_batch_size(dml_job_ptr, operations_count, &batch_buffer_length);

--- a/include/dml/dmldefs.h
+++ b/include/dml/dmldefs.h
@@ -53,6 +53,8 @@ extern "C" {
 
 #define DML_BASE_DRIVER_ERROR 100u                  /**< Base for all driver errors  */
 
+#define DML_MIN_BATCH_SIZE (4u)                     /**< Min batch size for bulk operations */
+
 /* ====== DML Macros ====== */
 #define DML_MAX(a, b) ( ((a) > (b)) ? (a) : (b) )   /**< Simple macro to find maximum between pair values */
 #define DML_MIN(a, b) ( ((a) < (b)) ? (a) : (b) )   /**< Simple macro to find minimum between pair values */

--- a/sources/c_api/dml_batch.cpp
+++ b/sources/c_api/dml_batch.cpp
@@ -79,7 +79,7 @@ extern "C" dml_status_t dml_get_batch_size(const dml_job_t *dml_job_ptr, uint32_
 {
     CHECK_NULL(dml_job_ptr);
     CHECK_NULL(byte_size_ptr);
-    if (task_count <= 3u)
+    if (task_count < DML_MIN_BATCH_SIZE)
     {
         return DML_STATUS_BATCH_SIZE_ERROR;
     }

--- a/tests/job_api_tests/unit/tb_batch_set.cpp
+++ b/tests/job_api_tests/unit/tb_batch_set.cpp
@@ -26,7 +26,7 @@ namespace dml
     {
         auto job_size             = 0u;
         auto byte_size            = 0u;
-        constexpr auto task_count = 4u;
+        constexpr auto task_count = DML_MIN_BATCH_SIZE;
         constexpr auto task_index = 0u;
 
         const auto get_job_size_status  = dml_get_job_size(dml::test::variables_t::path, &job_size);


### PR DESCRIPTION
This change is to allow applications to check whether their batch size is smaller than the minimum (4u) required by the DML library.