### PR TITLE
build: Fix the Clang warning on -Wstrict-prototypes

### DIFF
--- a/sources/core/src/sw_dispatcher/dml_cpuid.c
+++ b/sources/core/src/sw_dispatcher/dml_cpuid.c
@@ -41,7 +41,7 @@ dml_core_registers dml_core_cpuid(dml_register_t leaf)
     return dml_core_cpuidex(leaf, 0x0);
 }
 
-size_t dml_core_get_cache_size()
+size_t dml_core_get_cache_size(void)
 {
     static size_t cache_size = 0u;
 

--- a/sources/core/src/sw_dispatcher/dml_cpuid.h
+++ b/sources/core/src/sw_dispatcher/dml_cpuid.h
@@ -45,7 +45,7 @@ dml_core_registers dml_core_cpuidex(dml_register_t leaf, dml_register_t sub_leaf
 
 dml_core_registers dml_core_cpuid(dml_register_t leaf);
 
-size_t dml_core_get_cache_size();
+size_t dml_core_get_cache_size(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Add "void" to fix Clang build warning on:
	sources/core/src/sw_dispatcher/dml_cpuid.h:48:31: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
	size_t dml_core_get_cache_size();
	                              ^
	                               void
	sources/core/src/sw_dispatcher/dml_cpuid.c:44:31: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
	size_t dml_core_get_cache_size()
	                              ^
	                               void
	2 warnings generated.