### PR TITLE
Fix build on Windows: make libaccel_config.h be useable there

### DIFF
--- a/sources/core/src/hw_dispatcher/hw_queue.cpp
+++ b/sources/core/src/hw_dispatcher/hw_queue.cpp
@@ -7,12 +7,8 @@
 #if defined(__linux__)
 
 #include <fcntl.h>
-
-#if defined(__linux__)
-
 #include <sys/mman.h>
-
-#endif
+#include <unistd.h>
 
 #include "hw_queue.hpp"
 #include "legacy_headers/hardware_configuration_driver.h"

--- a/sources/core/src/hw_dispatcher/legacy_headers/hardware_configuration_driver.h
+++ b/sources/core/src/hw_dispatcher/legacy_headers/hardware_configuration_driver.h
@@ -8,12 +8,7 @@
 #define DML_SOURCES_HW_PATH_INCLUDE_HW_CONFIGURATION_DRIVER_H_
 
 #include "hardware_definitions.h"
-
-#if defined(__linux__)
-
 #include "libaccel_config.h"
-
-#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/sources/core/src/hw_dispatcher/legacy_headers/libaccel_config.h
+++ b/sources/core/src/hw_dispatcher/legacy_headers/libaccel_config.h
@@ -10,10 +10,14 @@
 #include <stdbool.h>
 #include <stdarg.h>
 #include <stdint.h>
-#include <unistd.h>
 #include <errno.h>
 #include <limits.h>
+
+#ifndef _WIN32
 #include <uuid/uuid.h>
+#else
+typedef unsigned char uuid_t[16];
+#endif
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
# Description
Without the declarations in it, we get a lot of build errors because the types aren't declared.

```
hardware_configuration_driver.h:56:39: warning: 'struct accfg_ctx' declared inside parameter list will not be visible outside of this definition or declaration
hw_configuration_driver.c:134:9: error: conflicting types for 'dsa_driver_new_context'; have 'int32_t(struct accfg_ctx **)' {aka 'int(struct accfg_ctx **)'}
hardware_configuration_driver.h:56:9: note: previous declaration of 'dsa_driver_new_context' with type 'int32_t(struct accfg_ctx **)' {aka 'int(struct accfg_ctx **)'}

hw_configuration_driver.c:188:21: error: return type is an incomplete type
```
etc.

Fixes #38.

No functional testing done. I've only confirmed that the build now succeeds on Windows, not even tried to run it there (it's not in scope for us at the moment).

No regression testing added because you don't have a public CI here on GitHub. Let me know once you add one and I'll add the MinGW build.